### PR TITLE
feat: 공통 컴포넌트 구현 AutocompleteInput

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,7 +2,6 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
 }
 
 .logo {

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,8 +1,10 @@
 import Button from './button/Button';
 
 import CheckboxButtonInput from './input/CheckboxButtonInput';
+import AutocompleteInput from './input/AutocompleteInput';
 
 export {
   Button,
   CheckboxButtonInput,
+  AutocompleteInput,
 }

--- a/frontend/src/components/input/AutocompleteInput.module.css
+++ b/frontend/src/components/input/AutocompleteInput.module.css
@@ -1,0 +1,32 @@
+.container {
+  height: 200px;
+  overflow: auto;
+  /*transition: all 1s ease;*/
+}
+
+.container input {
+  padding: 10px;
+  width: 200px;
+}
+/* TODO: open hide transition 구현
+.open {
+  opacity: 1;
+  transition: opacity 1s ease;
+}
+.hide {
+  opacity: 0;
+  transition: opacity 1s ease;
+  height: 200px;
+}
+*/
+
+.dropdown {
+  list-style: none;
+  text-align: left;
+  width: 200px;
+  background-color: rgba(100, 100, 100, 0.2);
+  padding: 4px 10px;
+}
+.dropdown li {
+  padding: 2px;
+}

--- a/frontend/src/components/input/AutocompleteInput.module.css
+++ b/frontend/src/components/input/AutocompleteInput.module.css
@@ -29,4 +29,5 @@
 }
 .dropdown li {
   padding: 2px;
+  cursor: pointer;
 }

--- a/frontend/src/components/input/AutocompleteInput.tsx
+++ b/frontend/src/components/input/AutocompleteInput.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import { AutocompleteInputProps, DropdownInputProps } from '../../model/components/input';
+import styles from './AutocompleteInput.module.css';
+
+const AutocompleteInput: React.FC<AutocompleteInputProps> = ({ options }) => {
+  const [inputValue, setInputValue] = useState('');
+  const [isDropdownOpened, setIsDropdownOpened] = useState(false);
+
+  const matchedOptions = (inputValue: string) => {
+    if (!inputValue) return [];
+    return options.filter(o => o.includes(inputValue));
+  };
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const currentInputValue = e.target.value;
+    setIsDropdownOpened(matchedOptions(currentInputValue).length > 0);
+    setInputValue(currentInputValue);
+  };
+
+  return (
+    <div className={styles.container}>
+      <input type="text" value={inputValue} onChange={onInputChange} />
+      {isDropdownOpened
+      ? <DropdownInput
+          className={`${isDropdownOpened ? styles.open : styles.hide}`}
+          options={matchedOptions(inputValue)} />
+      : inputValue && <EmptyDropdown />}
+    </div>
+  );
+};
+
+const DropdownInput: React.FC<DropdownInputProps> = ({ options, className }) => {
+  return (
+    <ul className={`${styles.dropdown} ${className}`}>
+      {options.map((option, i) => (
+        <li key={i.toString()}>{option}</li>
+      ))}
+    </ul>
+  );
+};
+
+const EmptyDropdown: React.FC<{ message?: string; }> = ({ message = 'No Options' }) => {
+  return <DropdownInput options={[message]} />;
+};
+
+export default AutocompleteInput;

--- a/frontend/src/components/input/AutocompleteInput.tsx
+++ b/frontend/src/components/input/AutocompleteInput.tsx
@@ -23,17 +23,24 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({ options }) => {
       {isDropdownOpened
       ? <DropdownInput
           className={`${isDropdownOpened ? styles.open : styles.hide}`}
-          options={matchedOptions(inputValue)} />
+          options={matchedOptions(inputValue)}
+          onChange={setInputValue}
+        />
       : inputValue && <EmptyDropdown />}
     </div>
   );
 };
 
-const DropdownInput: React.FC<DropdownInputProps> = ({ options, className }) => {
+const DropdownInput: React.FC<DropdownInputProps> = ({ options, className, onChange }) => {
+  const onDropdownSelect = (selected: string) => {
+    if (!onChange) return;
+    onChange(selected);
+  };
+
   return (
     <ul className={`${styles.dropdown} ${className}`}>
       {options.map((option, i) => (
-        <li key={i.toString()}>{option}</li>
+        <li key={i.toString()} onClick={() => onDropdownSelect(option)}>{option}</li>
       ))}
     </ul>
   );

--- a/frontend/src/components/input/AutocompleteInput.tsx
+++ b/frontend/src/components/input/AutocompleteInput.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
-import { AutocompleteInputProps, DropdownInputProps } from '../../model/components/input';
+import { AutocompleteInputProps, DropdownInputProps, LabelValuePair } from '../../model/components/input';
 import styles from './AutocompleteInput.module.css';
 
-const AutocompleteInput: React.FC<AutocompleteInputProps> = ({ options }) => {
+const AutocompleteInput: React.FC<AutocompleteInputProps> = ({ options, onChange: onSelectedChange }) => {
   const [inputValue, setInputValue] = useState('');
   const [isDropdownOpened, setIsDropdownOpened] = useState(false);
 
   const matchedOptions = (inputValue: string) => {
     if (!inputValue) return [];
-    return options.filter(o => o.includes(inputValue));
+    return options.filter(o => o.label.includes(inputValue));
   };
 
   const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -24,7 +24,10 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({ options }) => {
       ? <DropdownInput
           className={`${isDropdownOpened ? styles.open : styles.hide}`}
           options={matchedOptions(inputValue)}
-          onChange={setInputValue}
+          onChange={option => {
+            onSelectedChange(option);
+            setInputValue(option.label);
+          }}
         />
       : inputValue && <EmptyDropdown />}
     </div>
@@ -32,22 +35,23 @@ const AutocompleteInput: React.FC<AutocompleteInputProps> = ({ options }) => {
 };
 
 const DropdownInput: React.FC<DropdownInputProps> = ({ options, className, onChange }) => {
-  const onDropdownSelect = (selected: string) => {
+  const onDropdownSelect = (selected: LabelValuePair) => {
     if (!onChange) return;
     onChange(selected);
   };
 
   return (
     <ul className={`${styles.dropdown} ${className}`}>
-      {options.map((option, i) => (
-        <li key={i.toString()} onClick={() => onDropdownSelect(option)}>{option}</li>
+      {options.map(option => (
+        <li key={option.value} onClick={() => onDropdownSelect(option)}>{option.label}</li>
       ))}
     </ul>
   );
 };
 
 const EmptyDropdown: React.FC<{ message?: string; }> = ({ message = 'No Options' }) => {
-  return <DropdownInput options={[message]} />;
+  const emptyOption: LabelValuePair = { label: message, value: message };
+  return <DropdownInput options={[emptyOption]} />;
 };
 
 export default AutocompleteInput;

--- a/frontend/src/components/input/CheckboxButtonInput.tsx
+++ b/frontend/src/components/input/CheckboxButtonInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '../../components';
-import { Code, CheckableTagsInputProps } from '../../model/components/input';
+import { LabelValuePair, CheckableTagsInputProps } from '../../model/components/input';
 import styles from './CheckboxButtonInput.module.css';
 
 const removeAElementInArray = (elementToRemove: any, arr: any[]) => {
@@ -21,7 +21,7 @@ const CheckboxButtonInput: React.FC<CheckableTagsInputProps> = ({ options, selec
       onChange([...selected, currentTarget.id]);
   };
 
-  const selectedClassOrEmpty = (option: Code) => selected.includes(option.value) ? styles.selected : '';
+  const selectedClassOrEmpty = (option: LabelValuePair) => selected.includes(option.value) ? styles.selected : '';
 
   return (
     <div>

--- a/frontend/src/model/components/input.ts
+++ b/frontend/src/model/components/input.ts
@@ -11,3 +11,12 @@ export interface InputWithOptions<T = string> {
   onChange: (selected: T[]) => void;
   resolver?: (option: Code<T>) => string | T;
 }
+
+export interface AutocompleteInputProps {
+  options: string[];
+}
+
+export interface DropdownInputProps {
+  options: string[];
+  className?: string;
+}

--- a/frontend/src/model/components/input.ts
+++ b/frontend/src/model/components/input.ts
@@ -1,4 +1,4 @@
-export interface Code<T = string> {
+export interface LabelValuePair<T = string> {
   label: string;
   value: T;
 }
@@ -6,18 +6,19 @@ export interface Code<T = string> {
 export interface CheckableTagsInputProps extends InputWithOptions {}
 
 export interface InputWithOptions<T = string> {
-  options: Code<T>[];
+  options: LabelValuePair<T>[];
   selected: T[];
   onChange: (selected: T[]) => void;
-  resolver?: (option: Code<T>) => string | T;
+  resolver?: (option: LabelValuePair<T>) => string | T;
 }
 
 export interface AutocompleteInputProps {
-  options: string[];
+  options: LabelValuePair[];
+  onChange: (selected: LabelValuePair) => void;
 }
 
 export interface DropdownInputProps {
-  options: string[];
+  options: LabelValuePair[];
   className?: string;
-  onChange?: (s: string) => void;
+  onChange?: (s: LabelValuePair) => void;
 }

--- a/frontend/src/model/components/input.ts
+++ b/frontend/src/model/components/input.ts
@@ -19,4 +19,5 @@ export interface AutocompleteInputProps {
 export interface DropdownInputProps {
   options: string[];
   className?: string;
+  onChange?: (s: string) => void;
 }

--- a/frontend/src/model/components/input.ts
+++ b/frontend/src/model/components/input.ts
@@ -12,9 +12,9 @@ export interface InputWithOptions<T = string> {
   resolver?: (option: LabelValuePair<T>) => string | T;
 }
 
-export interface AutocompleteInputProps {
-  options: LabelValuePair[];
-  onChange: (selected: LabelValuePair) => void;
+export interface AutocompleteInputProps<T = string> {
+  options: LabelValuePair<T>[];
+  onChange: (selected: LabelValuePair<T>) => void;
 }
 
 export interface DropdownInputProps {

--- a/frontend/src/pages/exam.tsx
+++ b/frontend/src/pages/exam.tsx
@@ -6,9 +6,9 @@ import {
   AutocompleteInput,
   CheckboxButtonInput,
 } from '../components';
-import { Code } from '../model/components/input';
+import { LabelValuePair } from '../model/components/input';
 
-const options: Code[] = [
+const options: LabelValuePair[] = [
   { label: 'Code 1', value: 'code 1' },
   { label: 'Code 2', value: 'code 2' },
   { label: 'Code 3', value: 'code 3' },
@@ -64,27 +64,27 @@ const CheckboxButtonInputExam: React.FC = () => {
 };
 
 const AutocompleteInputExam: React.FC = () => {
+  const [selected, setSelected] = useState<LabelValuePair | null>(null);
   return (
     <>
       <h2>AutocompleteInput</h2>
-      <AutocompleteInput options={autocompleteOptions} />
+      {selected && <pre>{selected && `label: ${selected.label}, value: ${selected.value}`}</pre>}
+      <AutocompleteInput
+        options={autocompleteOptions}
+        onChange={setSelected} />
     </>
   );
 };
 
-const autocompleteOptions: string[] = [
-  '안녕',
-  '안녕하세요',
-  '안녕!',
-  '인녕',
-  '정경진입니다.',
-  'DevCalendar 화이팅',
-  'develop',
-  'develop',
-  'develop',
-  'develop',
-  'develop',
-  'develop',
+const autocompleteOptions: LabelValuePair[] = [
+  { label: '네이버', value: 'naver' },
+  { label: '네이버2', value: 'naver2' },
+  { label: '카카오', value: 'kakao' },
+  { label: '카카오2', value: 'kakao2' },
+  { label: '카카오3', value: 'kakao3' },
+  { label: '라인', value: 'line' },
+  { label: '쿠팡', value: 'coupang' },
+  { label: '배달의민족', value: 'woowa-brothers' },
 ];
 
 

--- a/frontend/src/pages/exam.tsx
+++ b/frontend/src/pages/exam.tsx
@@ -2,8 +2,11 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '../components';
 import '../assets/style.css';
-import CheckboxButtonInput from '../components/input/CheckboxButtonInput';
-import {CheckableTagsInputProps, Code} from '../model/components/input';
+import {
+  AutocompleteInput,
+  CheckboxButtonInput,
+} from '../components';
+import { Code } from '../model/components/input';
 
 const options: Code[] = [
   { label: 'Code 1', value: 'code 1' },
@@ -38,6 +41,7 @@ const Exam = () => (
     <section>
       <h1>Input</h1>
       <CheckboxButtonInputExam />
+      <AutocompleteInputExam />
     </section>
   </div>
 );
@@ -58,5 +62,30 @@ const CheckboxButtonInputExam: React.FC = () => {
     </>
   );
 };
+
+const AutocompleteInputExam: React.FC = () => {
+  return (
+    <>
+      <h2>AutocompleteInput</h2>
+      <AutocompleteInput options={autocompleteOptions} />
+    </>
+  );
+};
+
+const autocompleteOptions: string[] = [
+  '안녕',
+  '안녕하세요',
+  '안녕!',
+  '인녕',
+  '정경진입니다.',
+  'DevCalendar 화이팅',
+  'develop',
+  'develop',
+  'develop',
+  'develop',
+  'develop',
+  'develop',
+];
+
 
 export default Exam;


### PR DESCRIPTION
@GuruneLee 님, AutocompleteInput 구현했습니다. ([MUI 데모](https://mui.com/material-ui/react-autocomplete/))

평소에 Element UI나 Element Plus 같은 UI 라이브러리만 사용하다가 직접 구현해보니 감회가 새롭네요.
한 번에 다 구현하기는 시간이 촉박해서 앞으로 추가되면 좋을 기능들을 생각해보았습니다.

- 키보드 커서로 dropdown item 선택 기능
- 현재 입력한 inputValue와 동일한 항목 하이라이트 (색상이나 배경색)
- postfix에 remove icon 추가

이 외에 필요한 기능이 있다면 적어주세요!
이슈로 관리해서 누락 없도록 해야할 것 같아요.

감사합니다!